### PR TITLE
Add description to PyPI package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.0.3"
 description = "Cybsi Cloud development kit"
 authors = ["Cybsi Cloud developers"]
 license = "Apache License 2.0"
+readme = "README.md"
 packages = [
     { include = "cybsi" },
 ]


### PR DESCRIPTION
Чтобы было описание у пакетов в реестре PyPI, то необходимо предоставить ссылку на readme в pyproject.toml