### PR TITLE
Retry requests when transport errors occurred

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.1.4 (2024-07-17)
+------------------
+- Retry requests when transport errors occurred
+
 1.1.3 (2024-05-17)
 ------------------
 

--- a/cybsi/cloud/__version__.py
+++ b/cybsi/cloud/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __title__ = "cybsi-cloud-sdk"
 __description__ = "Cybsi Cloud development kit"
 __license__ = "Apache License 2.0"

--- a/cybsi/cloud/client.py
+++ b/cybsi/cloud/client.py
@@ -51,6 +51,7 @@ class Client:
             ssl_verify=config.ssl_verify,
             timeouts=config.timeouts,
             limits=config.limits,
+            retry=config.retry,
         )
 
     def __enter__(self) -> "Client":
@@ -110,6 +111,7 @@ class AsyncClient:
             ssl_verify=config.ssl_verify,
             timeouts=config.timeouts,
             limits=config.limits,
+            retry=config.retry,
         )
 
     async def __aenter__(self) -> "AsyncClient":

--- a/cybsi/cloud/client_config.py
+++ b/cybsi/cloud/client_config.py
@@ -126,8 +126,9 @@ class Timeouts:
         )
 
 
-DEFAULT_TIMEOUTS = Timeouts(default=60.0)
-DEFAULT_LIMITS = Limits(max_connections=100, max_keepalive_connections=20)
+_DEFAULT_TIMEOUTS = Timeouts(default=60.0)
+_DEFAULT_RETRY_COUNT = 3
+_DEFAULT_LIMITS = Limits(max_connections=100, max_keepalive_connections=20)
 
 
 class Config:
@@ -141,6 +142,8 @@ class Config:
             on all operations.
         limits:  Configuration for limits to various client behaviors.
             Default configuration is max_connections=100, max_keepalive_connections=20.
+        retry: The count of sending request attempts
+            if a connection or transport error occurred.
     """
 
     def __init__(
@@ -149,11 +152,13 @@ class Config:
         api_key: str,
         api_url: str = "https://cybsi.cloud",
         ssl_verify: bool = True,
-        timeouts: Timeouts = DEFAULT_TIMEOUTS,
-        limits: Limits = DEFAULT_LIMITS,
+        timeouts: Timeouts = _DEFAULT_TIMEOUTS,
+        limits: Limits = _DEFAULT_LIMITS,
+        retry: int = _DEFAULT_RETRY_COUNT,
     ):
         self.api_key = api_key
         self.api_url = api_url
         self.ssl_verify = ssl_verify
         self.timeouts = timeouts
         self.limits = limits
+        self.retry = retry if retry > 0 else 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cybsi-cloud-sdk"
-version = "1.1.3"
+version = "1.1.4"
 description = "Cybsi Cloud development kit"
 authors = ["Cybsi Cloud developers"]
 license = "Apache License 2.0"

--- a/tests/insight/test_schemas.py
+++ b/tests/insight/test_schemas.py
@@ -2,7 +2,7 @@ from typing import List, Any
 from unittest.mock import patch
 
 from cybsi.cloud import Tag
-from cybsi.cloud.client_config import DEFAULT_TIMEOUTS, DEFAULT_LIMITS
+from cybsi.cloud.client_config import _DEFAULT_TIMEOUTS, _DEFAULT_LIMITS, _DEFAULT_RETRY_COUNT
 from cybsi.cloud.insight import SchemaAPI
 from cybsi.cloud.internal import HTTPConnector
 from cybsi.cloud.pagination import chain_pages
@@ -16,8 +16,9 @@ class SchemasTest(BaseTest):
             base_url=self.base_url,
             auth=None,
             ssl_verify=True,
-            timeouts=DEFAULT_TIMEOUTS,
-            limits=DEFAULT_LIMITS,
+            timeouts=_DEFAULT_TIMEOUTS,
+            limits=_DEFAULT_LIMITS,
+            retry=_DEFAULT_RETRY_COUNT,
         )
         self.schemas_api = SchemaAPI(self.connector)
         self.schema_id = "test-schema"

--- a/tests/insight/test_task_queue.py
+++ b/tests/insight/test_task_queue.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from cybsi.cloud.internal import HTTPConnector, parse_rfc3339_timestamp, AsyncHTTPConnector
 
-from cybsi.cloud.client_config import DEFAULT_TIMEOUTS, DEFAULT_LIMITS
+from cybsi.cloud.client_config import _DEFAULT_TIMEOUTS, _DEFAULT_LIMITS, _DEFAULT_RETRY_COUNT
 from cybsi.cloud.insight import TaskQueueAPI, TaskQueueItemView, ObjectKeyView, ObjectType, ObjectKeyForm, \
     ObjectKeyType, TaskQueueAsyncAPI
 from tests import BaseTest, BaseAsyncTest
@@ -17,8 +17,9 @@ class TaskQueueAPITest(BaseTest):
             base_url=self.base_url,
             auth=None,
             ssl_verify=True,
-            timeouts=DEFAULT_TIMEOUTS,
-            limits=DEFAULT_LIMITS,
+            timeouts=_DEFAULT_TIMEOUTS,
+            limits=_DEFAULT_LIMITS,
+            retry=_DEFAULT_RETRY_COUNT,
         )
 
         self.task_queue_api = TaskQueueAPI(self.connector)
@@ -107,8 +108,9 @@ class TaskQueueAsyncAPITest(BaseAsyncTest):
             base_url=self.base_url,
             auth=None,
             ssl_verify=True,
-            timeouts=DEFAULT_TIMEOUTS,
-            limits=DEFAULT_LIMITS,
+            timeouts=_DEFAULT_TIMEOUTS,
+            limits=_DEFAULT_LIMITS,
+            retry=_DEFAULT_RETRY_COUNT,
         )
 
         self.task_queue_api = TaskQueueAsyncAPI(self.connector)


### PR DESCRIPTION
Предлагаю закрыть эпопею с "Server disconnected without sending response" путем перепосылки запросов в случаях, когда это возможно. 